### PR TITLE
Fix CubismMotionSyncCriProcessor の null 例外回避

### DIFF
--- a/Assets/Live2D/CubismMotionSyncPlugin/CHANGELOG.md
+++ b/Assets/Live2D/CubismMotionSyncPlugin/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [Unreleased] - 
+
+### Fixed
+
+Fix an issue with inadequate error handling for missing elements in `UpdateCubismMotionSync`. by [@ppcuni](https://github.com/ppcuni)
+
+
 ## [5-r.1-beta.3] - 2023-11-14
 
 ### Added

--- a/Assets/Live2D/CubismMotionSyncPlugin/Framework/Processor/CRI/CubismMotionSyncCriProcessor.cs
+++ b/Assets/Live2D/CubismMotionSyncPlugin/Framework/Processor/CRI/CubismMotionSyncCriProcessor.cs
@@ -316,7 +316,7 @@ namespace Live2D.CubismMotionSyncPlugin.Framework.Processor.CRI
         /// <param name="motionSyncData">motion sync data</param>
         public void UpdateCubismMotionSync(CubismMotionSyncData motionSyncData)
         {
-            if (!enabled || MotionSyncAudioInput == null || TargetModelParameters == null)
+            if (!enabled || MotionSyncAudioInput == null || TargetModelParameters == null || MotionSyncController == null)
             {
                 // Fail silently...
                 return;


### PR DESCRIPTION
CubismUpdateController の LateUpdate が CubismMotionSyncCriProcessor の Start より先に呼ばれることがある。 そのときに null 例外が起きていたので null チェックを追加