### PR TITLE
CubismMotionSyncCriEngine が予期せず Dispose される事があるのを修正

### DIFF
--- a/Assets/Live2D/CubismMotionSyncPlugin/Framework/Processor/CRI/CubismMotionSyncCriProcessor.cs
+++ b/Assets/Live2D/CubismMotionSyncPlugin/Framework/Processor/CRI/CubismMotionSyncCriProcessor.cs
@@ -158,9 +158,18 @@ namespace Live2D.CubismMotionSyncPlugin.Framework.Processor.CRI
         /// </summary>
         private float CurrentRemainTime { get; set; }
 
+        /// <summary>
+        /// <see cref="CubismMotionSyncCriEngine.InitializeEngine"/> was called or not
+        /// </summary>
+        /// <remarks>
+        /// Since it is not a good idea to call <see cref="CubismMotionSyncCriEngine.DisposeEngine"/> before <see cref="CubismMotionSyncCriEngine.InitializeEngine"/> is called cache whether it is initialized or not.
+        /// </remarks>
+        private bool IsEngineInitialized { get; set; }
+
         private void Start()
         {
             CubismMotionSyncCriEngine.InitializeEngine();
+            IsEngineInitialized = true;
 
 
             if (!CubismMotionSyncCriEngine.IsInitialized)
@@ -189,7 +198,8 @@ namespace Live2D.CubismMotionSyncPlugin.Framework.Processor.CRI
             }
 
 
-            CubismMotionSyncCriEngine.DisposeEngine();
+            if (IsEngineInitialized)
+                CubismMotionSyncCriEngine.DisposeEngine();
         }
 
         /// <summary>

--- a/Assets/Live2D/CubismMotionSyncPlugin/Framework/Processor/CRI/CubismMotionSyncCriProcessor.cs
+++ b/Assets/Live2D/CubismMotionSyncPlugin/Framework/Processor/CRI/CubismMotionSyncCriProcessor.cs
@@ -199,7 +199,9 @@ namespace Live2D.CubismMotionSyncPlugin.Framework.Processor.CRI
 
 
             if (IsEngineInitialized)
+            {
                 CubismMotionSyncCriEngine.DisposeEngine();
+            }
         }
 
         /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-* Fix an issue where `CubismMotionSyncEngine_CRI.DisposeEngine()` could be called at an unintended time.
+* Fix an issue where `CubismMotionSyncEngine_CRI.DisposeEngine()` could be called at an unintended time. by [@ppcuni](https://github.com/Live2D/CubismUnityMotionSyncComponents/pull/6)
 
 
 ## [5-r.1] - 2024-05-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [Unreleased] - ####-##-##
+
+### Fixed
+
+* Fix an issue where `CubismMotionSyncEngine_CRI.DisposeEngine()` could be called at an unintended time.
+
+
 ## [5-r.1] - 2024-05-30
 
 ### Added


### PR DESCRIPTION
複数の Live2D を同時にインスタンス化する際に、一部の CubismMotionSyncCriProcessor の enable を落とした状態でインスタンスを作り、enable が true になることなく Destroy された場合に問題が発生した。
(CubismMotionSyncCriProcessor.MotionSyncAudioInput はボイス再生時まで代入したくないのでインスタンス化直後は無効化するようにしていた。その状態でセリフを喋らない Live2D を登場させて退場させるシーンを作ったら再現した)

上記状況では、CubismMotionSyncCriProcessor の Start が呼ばれる回数と Destroy が呼ばれる回数の対称性が崩れる。
それにより CubismMotionSyncCriEngine.ReferenceCount に不整合が生じ、まだ有効な CubismMotionSyncCriProcessor があるのに CubismMotionSyncEngine_CRI.DisposeEngine が呼ばれてしまい、リップシンクが停止してしまう。